### PR TITLE
Better handle account renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.2] - 2026-06-07
+
+### Fixed
+
+- Fix renaming an account would orphan holdings within that account (George Dietrich)
+
+[0.3.2]: https://github.com/blacksmoke16/rebalancer/releases/tag/v0.3.2
+
 ## [0.3.1] - 2026-01-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rebalancer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rebalancer",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rebalancer",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/src/components/PortfolioInputTable.tsx
+++ b/src/components/PortfolioInputTable.tsx
@@ -49,7 +49,7 @@ const MobilePortfolioLayout = memo(function MobilePortfolioLayout({
                         {account.name}:
                       </Text>
                       <Text size="sm">
-                        ${(fund.values[account.name] || 0).toLocaleString()}
+                        ${(fund.values[account.key] || 0).toLocaleString()}
                       </Text>
                     </Group>
                   ))}

--- a/src/components/ui/AccountTotalsRow.tsx
+++ b/src/components/ui/AccountTotalsRow.tsx
@@ -24,7 +24,7 @@ export const AccountTotalsRow = memo<AccountTotalsRowProps>(
           {accounts.map((account) => (
             <TableTd key={`${account.key}-total`}>
               <Center>
-                <CurrencyCell value={totalForAccount(account.name)} />
+                <CurrencyCell value={totalForAccount(account.key)} />
               </Center>
             </TableTd>
           ))}

--- a/src/components/ui/AssetClassHeaderRow.tsx
+++ b/src/components/ui/AssetClassHeaderRow.tsx
@@ -33,7 +33,7 @@ export const AssetClassHeaderRow = memo<AssetClassHeaderRowProps>(
                   <CurrencyCell
                     value={totalForAssetClassAccount(
                       assetClass.name,
-                      account.name,
+                      account.key,
                     )}
                   />
                 </div>

--- a/src/components/ui/FundDataRow.tsx
+++ b/src/components/ui/FundDataRow.tsx
@@ -1,6 +1,7 @@
 import { Stack, TableTd, TableTr, Text } from "@mantine/core";
 import { memo } from "react";
 import { Account, AssetClass, Fund } from "../../types";
+import { AccountId } from "../../types/branded";
 import { usePortfolioContext } from "../../contexts/PortfolioContext";
 import { NumberField } from "./NumberField";
 import classes from "../../App.module.css";
@@ -15,9 +16,9 @@ interface FundDataRowProps {
 function getPendingChangeKey(
   assetClassName: string,
   fundTicker: string,
-  accountName: string,
+  accountId: AccountId,
 ): string {
-  return `${assetClassName}|${fundTicker}|${accountName}`;
+  return `${assetClassName}|${fundTicker}|${accountId}`;
 }
 
 export const FundDataRow = memo<FundDataRowProps>(function FundDataRow({
@@ -38,11 +39,11 @@ export const FundDataRow = memo<FundDataRowProps>(function FundDataRow({
       {isFirstFund && <TableTd rowSpan={assetClass.funds.length} />}
       <TableTd>{fund.ticker}</TableTd>
       {accounts.map((account) => {
-        const currentValue = fund.values[account.name] || 0;
+        const currentValue = fund.values[account.key] || 0;
         const pendingChangeKey = getPendingChangeKey(
           assetClass.name,
           fund.ticker,
-          account.name,
+          account.key,
         );
         const pendingChange = pendingChanges[pendingChangeKey] || 0;
         const projectedValue = currentValue + pendingChange;
@@ -66,7 +67,7 @@ export const FundDataRow = memo<FundDataRowProps>(function FundDataRow({
                     updatePendingChange(
                       assetClass.name,
                       fund.ticker,
-                      account.name,
+                      account.key,
                       cappedValue,
                     );
                   }}
@@ -87,7 +88,7 @@ export const FundDataRow = memo<FundDataRowProps>(function FundDataRow({
                   updateAssetAccountValue(
                     assetClass.name,
                     fund.ticker,
-                    account.name,
+                    account.key,
                     value,
                   );
                 }}

--- a/src/contexts/PortfolioContext.tsx
+++ b/src/contexts/PortfolioContext.tsx
@@ -2,13 +2,13 @@ import { useListState } from "@mantine/hooks";
 import { createContext, use } from "react";
 import { PendingChanges } from "../hooks/usePortfolioData";
 import { Account, AssetClass } from "../types";
-import { DollarAmount } from "../types/branded";
+import { AccountId, DollarAmount } from "../types/branded";
 
 export interface CalculationMethods {
-  totalForAccount: (accountName: string) => number;
+  totalForAccount: (accountId: AccountId) => number;
   totalForAssetClassAccount: (
     assetClassName: string,
-    accountName: string,
+    accountId: AccountId,
   ) => number;
   currentForAssetClass: (assetClass: AssetClass) => number;
   totalDollars: () => number;
@@ -28,13 +28,13 @@ export interface PortfolioContextValue {
   updateAssetAccountValue: (
     assetClassName: string,
     fundTicker: string,
-    accountName: string,
+    accountId: AccountId,
     value: number,
   ) => void;
   updatePendingChange: (
     assetClassName: string,
     fundTicker: string,
-    accountName: string,
+    accountId: AccountId,
     changeAmount: number,
   ) => void;
   enterPlanningMode: () => void;

--- a/src/hooks/usePortfolioCalculations.test.ts
+++ b/src/hooks/usePortfolioCalculations.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "../test/utils";
 import { usePortfolioCalculations } from "./usePortfolioCalculations";
-import { createDollarAmount, createPercentage } from "../types/branded";
+import {
+  AccountId,
+  createDollarAmount,
+  createPercentage,
+} from "../types/branded";
 import type { AssetClass } from "../types";
 
 describe("usePortfolioCalculations", () => {
+  // Holdings are keyed by account id; these stand in for those ids in the mocks.
+  const ACCOUNT_IDS = {
+    k401: "401k" as AccountId,
+    roth: "Roth IRA" as AccountId,
+    brokerage: "Brokerage" as AccountId,
+    hsa: "HSA" as AccountId,
+  };
+
   const mockPortfolio = [
     {
       name: "US Total Stock Market",
@@ -85,9 +97,9 @@ describe("usePortfolioCalculations", () => {
         usePortfolioCalculations(mockPortfolio, toInvest),
       );
 
-      expect(result.current.totalForAccount("401k")).toBe(5000); // 3000 + 1500 + 500
-      expect(result.current.totalForAccount("Roth IRA")).toBe(3300); // 2000 + 1000 + 300
-      expect(result.current.totalForAccount("Brokerage")).toBe(1700); // 1000 + 500 + 200
+      expect(result.current.totalForAccount(ACCOUNT_IDS.k401)).toBe(5000); // 3000 + 1500 + 500
+      expect(result.current.totalForAccount(ACCOUNT_IDS.roth)).toBe(3300); // 2000 + 1000 + 300
+      expect(result.current.totalForAccount(ACCOUNT_IDS.brokerage)).toBe(1700); // 1000 + 500 + 200
     });
 
     it("should return zero for non-existent account", () => {
@@ -95,7 +107,9 @@ describe("usePortfolioCalculations", () => {
         usePortfolioCalculations(mockPortfolio, toInvest),
       );
 
-      expect(result.current.totalForAccount("NonExistent")).toBe(0);
+      expect(result.current.totalForAccount("NonExistent" as AccountId)).toBe(
+        0,
+      );
     });
 
     it("should calculate total for asset class in specific account", () => {
@@ -106,17 +120,20 @@ describe("usePortfolioCalculations", () => {
       expect(
         result.current.totalForAssetClassAccount(
           "US Total Stock Market",
-          "401k",
+          ACCOUNT_IDS.k401,
         ),
       ).toBe(3000);
       expect(
         result.current.totalForAssetClassAccount(
           "International Stocks",
-          "Roth IRA",
+          ACCOUNT_IDS.roth,
         ),
       ).toBe(1000);
       expect(
-        result.current.totalForAssetClassAccount("Bonds", "Brokerage"),
+        result.current.totalForAssetClassAccount(
+          "Bonds",
+          ACCOUNT_IDS.brokerage,
+        ),
       ).toBe(200);
     });
 
@@ -126,12 +143,15 @@ describe("usePortfolioCalculations", () => {
       );
 
       expect(
-        result.current.totalForAssetClassAccount("NonExistent", "401k"),
+        result.current.totalForAssetClassAccount(
+          "NonExistent",
+          ACCOUNT_IDS.k401,
+        ),
       ).toBe(0);
       expect(
         result.current.totalForAssetClassAccount(
           "US Total Stock Market",
-          "NonExistent",
+          "NonExistent" as AccountId,
         ),
       ).toBe(0);
     });
@@ -394,7 +414,7 @@ describe("usePortfolioCalculations", () => {
       expect(
         result.current.totalForAssetClassAccount(
           "US Total Stock Market",
-          "401k",
+          ACCOUNT_IDS.k401,
         ),
       ).toBe(3500);
 
@@ -402,7 +422,7 @@ describe("usePortfolioCalculations", () => {
       expect(
         result.current.totalForAssetClassAccount(
           "International Stocks",
-          "Roth IRA",
+          ACCOUNT_IDS.roth,
         ),
       ).toBe(800);
 
@@ -426,15 +446,15 @@ describe("usePortfolioCalculations", () => {
       );
 
       // BND in HSA should now be 1000 (from 0)
-      expect(result.current.totalForAssetClassAccount("Bonds", "HSA")).toBe(
-        1000,
-      );
+      expect(
+        result.current.totalForAssetClassAccount("Bonds", ACCOUNT_IDS.hsa),
+      ).toBe(1000);
 
       // Total bonds: 1000 (original) + 1000 (pending) = 2000
       expect(result.current.currentForAssetClass(mockPortfolio[2])).toBe(2000);
 
       // HSA account total should be 1000
-      expect(result.current.totalForAccount("HSA")).toBe(1000);
+      expect(result.current.totalForAccount(ACCOUNT_IDS.hsa)).toBe(1000);
 
       // Overall total: 10000 + 1000 = 11000
       expect(result.current.totalDollars()).toBe(11000);
@@ -513,14 +533,14 @@ describe("usePortfolioCalculations", () => {
             {
               ticker: "VTI" as any,
               values: {
-                "401k": createDollarAmount(3000),
+                [ACCOUNT_IDS.k401]: createDollarAmount(3000),
               },
               key: "vti-key",
             },
             {
               ticker: "VTSAX" as any,
               values: {
-                "Roth IRA": createDollarAmount(2000),
+                [ACCOUNT_IDS.roth]: createDollarAmount(2000),
               },
               key: "vtsax-key",
             },

--- a/src/hooks/usePortfolioCalculations.ts
+++ b/src/hooks/usePortfolioCalculations.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { AssetClass } from "../types";
+import { AccountId } from "../types/branded";
 import { PendingChanges } from "./usePortfolioData";
 
 interface UsePortfolioCalculationsReturn {
@@ -7,10 +8,10 @@ interface UsePortfolioCalculationsReturn {
   currentPercentage: (assetClass: AssetClass) => number;
   targetDollars: (assetClass: AssetClass) => number;
   amountToBuy: (assetClass: AssetClass) => number;
-  totalForAccount: (accountName: string) => number;
+  totalForAccount: (accountId: AccountId) => number;
   totalForAssetClassAccount: (
     assetClassName: string,
-    accountName: string,
+    accountId: AccountId,
   ) => number;
   totalDollars: () => number;
 }
@@ -18,9 +19,9 @@ interface UsePortfolioCalculationsReturn {
 function getPendingChangeKey(
   assetClassName: string,
   fundTicker: string,
-  accountName: string,
+  accountId: AccountId,
 ): string {
-  return `${assetClassName}|${fundTicker}|${accountName}`;
+  return `${assetClassName}|${fundTicker}|${accountId}`;
 }
 
 export function usePortfolioCalculations(
@@ -35,12 +36,12 @@ export function usePortfolioCalculations(
       currentValue: number,
       assetClassName: string,
       fundTicker: string,
-      accountName: string,
+      accountId: AccountId,
     ): number => {
       if (!usePendingValues) {
         return currentValue;
       }
-      const key = getPendingChangeKey(assetClassName, fundTicker, accountName);
+      const key = getPendingChangeKey(assetClassName, fundTicker, accountId);
       const pendingChange = pendingChanges[key] ?? 0;
       return currentValue + pendingChange;
     },
@@ -54,12 +55,12 @@ export function usePortfolioCalculations(
         assetClass.funds.reduce((fundAcc, fund) => {
           // Sum values from existing fund.values entries
           let fundTotal = Object.entries(fund.values).reduce(
-            (valueAcc, [accountName, value]) => {
+            (valueAcc, [accountId, value]) => {
               const effectiveValue = getEffectiveValue(
                 value,
                 assetClass.name,
                 fund.ticker,
-                accountName,
+                accountId as AccountId,
               );
               return valueAcc + effectiveValue;
             },
@@ -100,17 +101,17 @@ export function usePortfolioCalculations(
 
   // Stable utility functions that only depend on portfolio structure
   const totalForAccount = useCallback(
-    (accountName: string): number => {
+    (accountId: AccountId): number => {
       return portfolio.reduce((assetAcc, assetClass) => {
         return (
           assetAcc +
           assetClass.funds.reduce((fundAcc, fund) => {
-            const currentValue = fund.values[accountName] ?? 0;
+            const currentValue = fund.values[accountId] ?? 0;
             const effectiveValue = getEffectiveValue(
               currentValue,
               assetClass.name,
               fund.ticker,
-              accountName,
+              accountId,
             );
             return fundAcc + effectiveValue;
           }, 0)
@@ -121,17 +122,17 @@ export function usePortfolioCalculations(
   );
 
   const totalForAssetClassAccount = useCallback(
-    (assetClassName: string, accountName: string): number => {
+    (assetClassName: string, accountId: AccountId): number => {
       const assetClass = portfolio.find((ac) => ac.name === assetClassName);
       if (!assetClass) return 0;
 
       return assetClass.funds.reduce((fundAcc, fund) => {
-        const currentValue = fund.values[accountName] ?? 0;
+        const currentValue = fund.values[accountId] ?? 0;
         const effectiveValue = getEffectiveValue(
           currentValue,
           assetClass.name,
           fund.ticker,
-          accountName,
+          accountId,
         );
         return fundAcc + effectiveValue;
       }, 0);
@@ -144,12 +145,12 @@ export function usePortfolioCalculations(
       return assetClass.funds.reduce((fundAcc, fund) => {
         // Sum values from existing fund.values entries
         let fundTotal = Object.entries(fund.values).reduce(
-          (valueAcc, [accountName, value]) => {
+          (valueAcc, [accountId, value]) => {
             const effectiveValue = getEffectiveValue(
               value,
               assetClass.name,
               fund.ticker,
-              accountName,
+              accountId as AccountId,
             );
             return valueAcc + effectiveValue;
           },

--- a/src/hooks/usePortfolioData.test.ts
+++ b/src/hooks/usePortfolioData.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "../test/utils";
+import { usePortfolioData } from "./usePortfolioData";
+import { usePortfolioCalculations } from "./usePortfolioCalculations";
+
+// Composes the data and calculation hooks the way the app does, exposing both
+// the mutators and the derived per-account totals.
+function usePortfolio() {
+  const data = usePortfolioData();
+  const calculations = usePortfolioCalculations(data.portfolio, data.toInvest);
+  return { ...data, calculations };
+}
+
+describe("usePortfolioData", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("preserves an account's holdings when it is renamed", async () => {
+    const { result } = renderHook(() => usePortfolio());
+
+    // Wait for the default data to load.
+    await waitFor(() => {
+      expect(result.current.accounts.length).toBeGreaterThan(0);
+    });
+
+    const account = result.current.accounts[0];
+    const holdingsBefore = result.current.calculations.totalForAccount(
+      account.key,
+    );
+    expect(holdingsBefore).toBeGreaterThan(0);
+
+    // Rename the account, keeping its stable key (what the settings form does).
+    act(() => {
+      result.current.accountList.setState((accounts) =>
+        accounts.map((a) =>
+          a.key === account.key ? { ...a, name: `${a.name} (renamed)` } : a,
+        ),
+      );
+    });
+
+    // The renamed account still owns the same holdings.
+    expect(result.current.calculations.totalForAccount(account.key)).toBe(
+      holdingsBefore,
+    );
+  });
+});

--- a/src/hooks/usePortfolioData.ts
+++ b/src/hooks/usePortfolioData.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { STORAGE } from "../constants";
 import { loadPortfolioData, savePortfolioData } from "../storage";
 import { Account, AssetClass } from "../types";
-import { createDollarAmount, DollarAmount } from "../types/branded";
+import { AccountId, createDollarAmount, DollarAmount } from "../types/branded";
 import { defaultAccounts, defaultAssetClasses } from "../utils";
 
 export type PendingChanges = Record<string, number>;
@@ -11,9 +11,9 @@ export type PendingChanges = Record<string, number>;
 function getPendingChangeKey(
   assetClassName: string,
   fundTicker: string,
-  accountName: string,
+  accountId: AccountId,
 ): string {
-  return `${assetClassName}|${fundTicker}|${accountName}`;
+  return `${assetClassName}|${fundTicker}|${accountId}`;
 }
 
 interface UsePortfolioDataReturn {
@@ -26,13 +26,13 @@ interface UsePortfolioDataReturn {
   updateAssetAccountValue: (
     assetClassName: string,
     fundTicker: string,
-    accountName: string,
+    accountId: AccountId,
     value: number,
   ) => void;
   updatePendingChange: (
     assetClassName: string,
     fundTicker: string,
-    accountName: string,
+    accountId: AccountId,
     changeAmount: number,
   ) => void;
   enterPlanningMode: () => void;
@@ -55,7 +55,7 @@ export function usePortfolioData(): UsePortfolioDataReturn {
     defaultAccounts(),
   );
   const [portfolio, portfolioList] = useListState<AssetClass>(() =>
-    defaultAssetClasses(),
+    defaultAssetClasses(accounts),
   );
   const [toInvest, setToInvest] = useState(() => createDollarAmount(1500));
   const [isLoaded, setIsLoaded] = useState(false);
@@ -106,7 +106,7 @@ export function usePortfolioData(): UsePortfolioDataReturn {
     (
       assetClassName: string,
       fundTicker: string,
-      accountName: string,
+      accountId: AccountId,
       value: number,
     ): void => {
       portfolioList.setState((prev) =>
@@ -122,7 +122,7 @@ export function usePortfolioData(): UsePortfolioDataReturn {
                 ...fund,
                 values: {
                   ...fund.values,
-                  [accountName]: createDollarAmount(value),
+                  [accountId]: createDollarAmount(value),
                 },
               };
             }),
@@ -150,7 +150,7 @@ export function usePortfolioData(): UsePortfolioDataReturn {
 
   const resetToDefaults = useCallback((): void => {
     const defaultAccountsList = defaultAccounts();
-    const defaultPortfolioList = defaultAssetClasses();
+    const defaultPortfolioList = defaultAssetClasses(defaultAccountsList);
     const defaultToInvestValue = createDollarAmount(1500);
 
     accountList.setState(defaultAccountsList);
@@ -169,10 +169,10 @@ export function usePortfolioData(): UsePortfolioDataReturn {
     (
       assetClassName: string,
       fundTicker: string,
-      accountName: string,
+      accountId: AccountId,
       changeAmount: number,
     ): void => {
-      const key = getPendingChangeKey(assetClassName, fundTicker, accountName);
+      const key = getPendingChangeKey(assetClassName, fundTicker, accountId);
       setPendingChanges((prev) => {
         // Remove the entry if the change is zero
         if (changeAmount === 0) {
@@ -202,7 +202,11 @@ export function usePortfolioData(): UsePortfolioDataReturn {
   const applyPendingChanges = useCallback((): void => {
     // Apply each pending change to the actual holdings
     Object.entries(pendingChanges).forEach(([key, changeAmount]) => {
-      const [assetClassName, fundTicker, accountName] = key.split("|");
+      const [assetClassName, fundTicker, accountId] = key.split("|") as [
+        string,
+        string,
+        AccountId,
+      ];
 
       // Find current value
       const assetClass = portfolio.find((ac) => ac.name === assetClassName);
@@ -211,16 +215,11 @@ export function usePortfolioData(): UsePortfolioDataReturn {
       const fund = assetClass.funds.find((f) => f.ticker === fundTicker);
       if (!fund) return;
 
-      const currentValue = fund.values[accountName] ?? 0;
+      const currentValue = fund.values[accountId] ?? 0;
       const newValue = currentValue + changeAmount;
 
       // Update the value
-      updateAssetAccountValue(
-        assetClassName,
-        fundTicker,
-        accountName,
-        newValue,
-      );
+      updateAssetAccountValue(assetClassName, fundTicker, accountId, newValue);
     });
 
     // Clear planning mode state

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -319,6 +319,42 @@ describe("Storage Utilities", () => {
       expect(result).toEqual(mockData);
     });
 
+    it("remaps name-keyed balances onto account ids on import", async () => {
+      const oldFormat = {
+        accounts: [
+          { name: "401k", key: "acct-1" },
+          { name: "Roth IRA", key: "acct-2" },
+        ],
+        portfolio: [
+          {
+            name: "US Total Stock Market",
+            allocation: 100,
+            key: "ac-1",
+            funds: [
+              {
+                ticker: "VTI",
+                key: "f-1",
+                values: { "401k": 1000, "Roth IRA": 500 },
+              },
+            ],
+          },
+        ],
+        toInvest: 0,
+        version: "1.0.0",
+        lastSaved: "2024-01-01T00:00:00.000Z",
+      };
+      const mockFile = new File([JSON.stringify(oldFormat)], "portfolio.json", {
+        type: "application/json",
+      });
+
+      const result = await importPortfolioData(mockFile);
+
+      expect(result.portfolio[0].funds[0].values).toEqual({
+        "acct-1": 1000,
+        "acct-2": 500,
+      });
+    });
+
     it("should reject invalid JSON files", async () => {
       const mockFile = new File(["invalid json"], "portfolio.json", {
         type: "application/json",
@@ -359,11 +395,65 @@ describe("Storage Utilities", () => {
         };
       });
 
-      (global as any).FileReader = mockFileReader;
+      vi.stubGlobal("FileReader", mockFileReader);
 
       await expect(importPortfolioData(mockFile)).rejects.toThrow(
         "Failed to read file",
       );
+    });
+  });
+
+  describe("balance key migration", () => {
+    const accounts = [
+      { name: "401k", key: "acct-1" },
+      { name: "Roth IRA", key: "acct-2" },
+    ];
+
+    function portfolioWithBalances(values: Record<string, number>) {
+      return [
+        {
+          name: "US Total Stock Market",
+          allocation: 100,
+          key: "ac-1",
+          funds: [{ ticker: "VTI", key: "f-1", values }],
+        },
+      ];
+    }
+
+    function storedData(values: Record<string, number>) {
+      return {
+        accounts,
+        portfolio: portfolioWithBalances(values),
+        toInvest: 0,
+        version: "1.0.0",
+        lastSaved: "2024-01-01T00:00:00.000Z",
+      };
+    }
+
+    it("remaps name-keyed balances onto account ids when loading", () => {
+      (localStorage.getItem as any).mockReturnValue(
+        JSON.stringify(storedData({ "401k": 1000, "Roth IRA": 500 })),
+      );
+
+      const result = loadPortfolioData();
+
+      expect(result?.portfolio[0].funds[0].values).toEqual({
+        "acct-1": 1000,
+        "acct-2": 500,
+      });
+    });
+
+    it("leaves already id-keyed balances untouched (idempotent)", () => {
+      (localStorage.getItem as any).mockReturnValue(
+        JSON.stringify(storedData({ "acct-1": 1000, "acct-2": 500 })),
+      );
+
+      const result = loadPortfolioData();
+
+      expect(result?.portfolio[0].funds[0].values).toEqual({
+        "acct-1": 1000,
+        "acct-2": 500,
+      });
     });
   });
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,6 @@
 import { STORAGE } from "./constants";
-import { Account, AssetClass, PortfolioData } from "./types";
-import { createDollarAmount, DollarAmount } from "./types/branded";
+import { Account, AccountBalances, AssetClass, PortfolioData } from "./types";
+import { AccountId, createDollarAmount, DollarAmount } from "./types/branded";
 import { defaultAccounts, defaultAssetClasses } from "./utils";
 
 export function savePortfolioData(
@@ -47,7 +47,7 @@ export function loadPortfolioData(): PortfolioData | null {
       return null;
     }
 
-    return data;
+    return migrateBalanceKeys(data);
   } catch {
     console.error("Failed to load portfolio data from localStorage");
     return null;
@@ -55,13 +55,43 @@ export function loadPortfolioData(): PortfolioData | null {
 }
 
 export function getDefaultPortfolioData(): PortfolioData {
+  const accounts = defaultAccounts();
   return {
-    accounts: defaultAccounts(),
-    portfolio: defaultAssetClasses(),
+    accounts,
+    portfolio: defaultAssetClasses(accounts),
     toInvest: createDollarAmount(0),
     version: STORAGE.VERSION,
     lastSaved: new Date().toISOString(),
   };
+}
+
+// Holdings are keyed by account id. Data saved by earlier versions keyed them
+// by account name, which orphaned balances whenever an account was renamed.
+// This remaps any name-keyed balances onto the matching account's id, leaving
+// already id-keyed (or unrecognized) entries untouched so it is safe to re-run.
+function migrateBalanceKeys(data: PortfolioData): PortfolioData {
+  const idByName = new Map<string, AccountId>();
+  const knownIds = new Set<string>();
+  for (const account of data.accounts) {
+    idByName.set(account.name, account.key);
+    knownIds.add(account.key);
+  }
+
+  const portfolio = data.portfolio.map((assetClass) => ({
+    ...assetClass,
+    funds: assetClass.funds.map((fund) => {
+      const values: AccountBalances = {};
+      for (const [key, value] of Object.entries(fund.values)) {
+        const idForName = idByName.get(key);
+        const targetId =
+          idForName && !knownIds.has(key) ? idForName : (key as AccountId);
+        values[targetId] = value;
+      }
+      return { ...fund, values };
+    }),
+  }));
+
+  return { ...data, portfolio };
 }
 
 export function exportPortfolioData(
@@ -103,7 +133,7 @@ export function importPortfolioData(file: File): Promise<PortfolioData> {
           return;
         }
 
-        resolve(data);
+        resolve(migrateBalanceKeys(data));
       } catch {
         reject(new Error("Failed to parse JSON file"));
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface Account {
   key: AccountId;
 }
 
-export type AccountBalances = Record<string, DollarAmount>;
+export type AccountBalances = Record<AccountId, DollarAmount>;
 
 export interface Fund {
   ticker: FundTicker;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,10 @@ export function defaultAccounts(): Account[] {
   ];
 }
 
-export function defaultAssetClasses(): AssetClass[] {
+// Builds the default holdings keyed by the given accounts' ids, so the seeded
+// balances stay attached to those accounts regardless of how they're renamed.
+export function defaultAssetClasses(accounts: Account[]): AssetClass[] {
+  const [taxDeferred, roth, taxable] = accounts;
   return [
     {
       name: "US Total Stock Market",
@@ -25,9 +28,9 @@ export function defaultAssetClasses(): AssetClass[] {
         {
           ticker: createFundTicker("VTI"),
           values: {
-            "401k": createDollarAmount(3730),
-            "Roth IRA": createDollarAmount(6927),
-            "Taxable Brokerage": createDollarAmount(19714),
+            [taxDeferred.key]: createDollarAmount(3730),
+            [roth.key]: createDollarAmount(6927),
+            [taxable.key]: createDollarAmount(19714),
           },
           key: randomId(),
         },
@@ -41,7 +44,7 @@ export function defaultAssetClasses(): AssetClass[] {
         {
           ticker: createFundTicker("VXUS"),
           values: {
-            "401k": createDollarAmount(17573),
+            [taxDeferred.key]: createDollarAmount(17573),
           },
           key: randomId(),
         },
@@ -55,7 +58,7 @@ export function defaultAssetClasses(): AssetClass[] {
         {
           ticker: createFundTicker("BND"),
           values: {
-            "401k": createDollarAmount(5090),
+            [taxDeferred.key]: createDollarAmount(5090),
           },
           key: randomId(),
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**", "**/tests/**"],
+    // Randomize order to surface inter-test ordering dependencies.
+    sequence: { shuffle: true },
+    // Restore globals patched via vi.stubGlobal between tests.
+    unstubGlobals: true,
   },
 });


### PR DESCRIPTION
Fixes #52 

The root cause was that all of the logic was using the name of the account to key into the data layer. Thus when you renamed an account, those keys still had the old values and thus defaulted to `0` as they would be missing.

This PR refactors the data format to key things based off random unique IDs per account to make things more robust. This does mean there is a breaking change in the data in localstorage. However I added a migration that'll automatically migrate the old format to the new format, so will be a seamless change to end users.